### PR TITLE
Nemo 4933: add validations for from_value/rate to eliminate MySQL errors for large values

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,8 @@ gemspec
 
 group :development, :test do
   gem 'rails', '~> 4.0.5'
-  gem 'factory_girl_rails', '~> 4.0'
   gem 'simplecov-rcov'
   gem 'yarjuf'
   gem 'require_all'
-  gem 'test-unit'
   gem 'byebug'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ group :development, :test do
   gem 'yarjuf'
   gem 'require_all'
   gem 'byebug'
+  gem 'shoulda-matchers'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ task :coverage do
   ENV['COVERAGE'] = 'true'
   Rake::Task["spec"].execute
 end
-task :default => :spec
+task default: :spec
 
 
 Bundler::GemHelper.install_tasks

--- a/app/models/spree/calculator/shipping/weight_based_order.rb
+++ b/app/models/spree/calculator/shipping/weight_based_order.rb
@@ -33,7 +33,7 @@ module Spree
       end
 
       def available?(package)
-        package.contents.any? && Spree::WeightBasedCalculatorRate.for_calculator(self.id).count > 0
+        package.contents.any? && Spree::WeightBasedCalculatorRate.for_calculator(id).size > 0
       end
 
       def self.register
@@ -57,16 +57,16 @@ module Spree
 
       # Get the rate from the database or nil if could not find the rate
       def get_rate(value)
-        Spree::WeightBasedCalculatorRate.find_rate(self.id, value)
+        Spree::WeightBasedCalculatorRate.find_rate(id, value)
       end
 
       def validate_at_least_one_rate
-        errors.add(:rates,  Spree.t('errors.must_have_at_least_one_shipping_rate')) unless rates.length > 0
+        errors.add(:rates,  Spree.t('errors.must_have_at_least_one_shipping_rate')) unless rates.size > 0
       end
 
       def validate_rates_uniqueness
         new_or_existing_rates = rates.reject { |r| r.marked_for_destruction? }
-        errors.add(:rates, Spree.t('errors.weight_based_shipping_must_be_unique'))  if new_or_existing_rates.map(&:from_value).uniq.length < new_or_existing_rates.length
+        errors.add(:rates, Spree.t('errors.weight_based_shipping_must_be_unique'))  if new_or_existing_rates.map(&:from_value).uniq.size < new_or_existing_rates.size
       end
     end
   end

--- a/app/models/spree/calculator/shipping/weight_based_order.rb
+++ b/app/models/spree/calculator/shipping/weight_based_order.rb
@@ -5,15 +5,15 @@ module Spree
     class WeightBasedOrder < ShippingCalculator
       has_many :rates,
                -> { order("from_value ASC") },
-               :class_name => 'Spree::WeightBasedCalculatorRate',
-               :foreign_key => :calculator_id,
-               :dependent => :destroy
+               class_name: 'Spree::WeightBasedCalculatorRate',
+               foreign_key: :calculator_id,
+               dependent: :destroy
 
       accepts_nested_attributes_for :rates,
-                                    :allow_destroy => true
+                                    allow_destroy: true
 
       # If weight is not defined for an item, use this instead
-      preference :default_item_weight, :decimal, :default => 0
+      preference :default_item_weight, :decimal, default: 0
 
       validate :validate_at_least_one_rate, :validate_rates_uniqueness
 

--- a/app/models/spree/weight_based_calculator_rate.rb
+++ b/app/models/spree/weight_based_calculator_rate.rb
@@ -2,11 +2,13 @@ module Spree
   class WeightBasedCalculatorRate < ActiveRecord::Base
     belongs_to :calculator, class_name: 'Spree::Calculator::Shipping::WeightBasedOrder'
 
-    scope :for_calculator, -> (calculator_id) { where(:calculator_id => calculator_id) }
+    scope :for_calculator, -> (calculator_id) { where(calculator_id: calculator_id) }
     scope :for_value, -> (value) { where("from_value <= ?", value) }
 
-    validates :from_value, :rate, :presence => true
-    validates :from_value, :rate, :numericality => { greater_than_or_equal_to: 0 }, :allow_blank => false
+    validates :from_value, :rate, presence: true
+    validates :from_value, numericality: { greater_than_or_equal_to: 0.0, less_than_or_equal_to: 99999.999 }, allow_blank: false
+    validates :rate, numericality: { greater_than_or_equal_to: 0.0, less_than_or_equal_to: 999999.99 }, allow_blank: false
+
 
     # Find the rate for the specified value
     def self.find_rate(calculator_id, value)

--- a/db/migrate/20140507224230_create_spree_weight_based_calculator_rates.rb
+++ b/db/migrate/20140507224230_create_spree_weight_based_calculator_rates.rb
@@ -2,10 +2,10 @@ class CreateSpreeWeightBasedCalculatorRates < ActiveRecord::Migration
   def change
     create_table :spree_weight_based_calculator_rates do |t|
       t.belongs_to :calculator
-      t.decimal :from_value,        :null => false, :precision => 8, :scale => 3, :default => 0.0
-      t.decimal :rate,              :null => false, :precision => 8, :scale => 2, :default => 0.0
+      t.decimal :from_value,        null: false, precision: 8, scale: 3, default: 0.0
+      t.decimal :rate,              null: false, precision: 8, scale: 2, default: 0.0
 
-      t.timestamps :null => false
+      t.timestamps null: false
     end
 
     add_index(:spree_weight_based_calculator_rates, :calculator_id)

--- a/lib/generators/spree_weight_based_shipping_calculator/install/install_generator.rb
+++ b/lib/generators/spree_weight_based_shipping_calculator/install/install_generator.rb
@@ -4,7 +4,7 @@ module SpreeWeightBasedShippingCalculator
   module Generators
     class InstallGenerator < Rails::Generators::Base
 
-      class_option :auto_run_migrations, :type => :boolean, :default => false
+      class_option :auto_run_migrations, type: :boolean, default: false
 
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=spree_weight_based_shipping_calculator'

--- a/lib/spree_weight_based_shipping_calculator/factories.rb
+++ b/lib/spree_weight_based_shipping_calculator/factories.rb
@@ -1,14 +1,9 @@
 FactoryGirl.define do
-  # Define your Spree extensions Factories within this file to enable applications, and other extensions to use and override them.
-  #
-  # Example adding this to your spec_helper will load these Factories for use:
-  # require 'spree_weight_based_shipping_calculator/factories'
-
-  factory :weight_based_shipping_calculator, :class => Spree::Calculator::Shipping::WeightBasedOrder do
+  factory :weight_based_shipping_calculator, class: Spree::Calculator::Shipping::WeightBasedOrder do
     calculable { Spree::ShippingMethod.first }
   end
 
-  factory :weight_based_calculator_rate, :class => Spree::WeightBasedCalculatorRate do
+  factory :weight_based_calculator_rate, class: Spree::WeightBasedCalculatorRate do
     calculator { Spree::Calculator::Shipping::WeightBasedOrder.first }
   end
 end

--- a/spec/models/spree/calculator/shipping/weight_based_order_spec.rb
+++ b/spec/models/spree/calculator/shipping/weight_based_order_spec.rb
@@ -39,6 +39,9 @@ describe Spree::Calculator::Shipping::WeightBasedOrder do
                                        contents: [Spree::Stock::Package::ContentItem.new(nil, variant1, 2),
                                                   Spree::Stock::Package::ContentItem.new(nil, variant2, 3)]) }
 
+  it { should have_many(:rates)}
+
+
   context "there are no items in the package" do
     before(:each) do
       calculator.rates << rate1

--- a/spec/models/spree/calculator/shipping/weight_based_order_spec.rb
+++ b/spec/models/spree/calculator/shipping/weight_based_order_spec.rb
@@ -8,27 +8,29 @@ describe Spree::Calculator::Shipping::WeightBasedOrder do
   let(:calculator) { FactoryGirl.build(:weight_based_shipping_calculator) }
 
   let(:rate1) { FactoryGirl.build(:weight_based_calculator_rate,
-                                  :from_value => 0,
-                                  :rate => 10) }
+                                  from_value: 0,
+                                  rate: 10) }
   let(:rate2) { FactoryGirl.build(:weight_based_calculator_rate,
-                                  :from_value => 8,
-                                  :rate => 15) }
+                                  from_value: 8,
+                                  rate: 15) }
   let(:rate3) { FactoryGirl.build(:weight_based_calculator_rate,
-                                  :from_value => 20,
-                                  :rate => 25) }
+                                  from_value: 20,
+                                  rate: 25) }
 
   let(:variant1) { double(Spree::Variant,
                           weight: 3,
-                          width: 1,
-                          depth: 1,
+                          width:  1,
+                          depth:  1,
                           height: 1,
-                          price: 2) }
+                          price:  2)
+                  }
   let(:variant2) { double(Spree::Variant,
                           weight: 4,
-                          width: 1,
-                          depth: 1,
+                          width:  1,
+                          depth:  1,
                           height: 1,
-                          price: 5) }
+                          price:  5)
+                  }
 
   let(:empty_package) { double(Spree::Stock::Package, order: mock_model(Spree::Order), contents: []) }
   let(:package_with_one_item) { double(Spree::Stock::Package, order: mock_model(Spree::Order),
@@ -38,7 +40,6 @@ describe Spree::Calculator::Shipping::WeightBasedOrder do
                                                   Spree::Stock::Package::ContentItem.new(nil, variant2, 3)]) }
 
   context "there are no items in the package" do
-
     before(:each) do
       calculator.rates << rate1
       calculator.save!
@@ -51,7 +52,7 @@ describe Spree::Calculator::Shipping::WeightBasedOrder do
     end
 
     it "is not available" do
-      expect(calculator.available?(empty_package)).to be_false
+      expect(calculator.available?(empty_package)).to be false
     end
   end
 
@@ -64,7 +65,7 @@ describe Spree::Calculator::Shipping::WeightBasedOrder do
     end
 
     it "calculates correct rate for one item with zero weight" do
-      package_with_one_item.contents[0].variant.stub(weight: 0)
+      allow(package_with_one_item.contents[0].variant).to receive(:weight).and_return(0)
 
       rate = calculator.compute_package(package_with_one_item)
       expect(rate).to eq(10)
@@ -81,7 +82,7 @@ describe Spree::Calculator::Shipping::WeightBasedOrder do
     end
 
     it "calculates correct rate for two items with total weight 18" do
-      package_with_two_item.contents[0].variant.stub(weight: 10)
+      allow(package_with_two_item.contents[0].variant).to receive(:weight).and_return(10)
 
       rate = calculator.compute_package(package_with_one_item)
       expect(rate).to eq(25)

--- a/spec/models/spree/weight_based_calculator_rate_spec.rb
+++ b/spec/models/spree/weight_based_calculator_rate_spec.rb
@@ -16,100 +16,53 @@ describe Spree::WeightBasedCalculatorRate do
                                   from_value: 8,
                                   rate: 15) }
 
-  context "without validation errors" do
-    it "should not have validation errors with valid attributes" do
-      expect(rate1).to be_valid
+  it { should belong_to(:calculator) }
+
+  specify { expect(rate1).to be_valid }
+
+  it { should validate_presence_of(:from_value) }
+  it { should validate_numericality_of(:from_value).is_greater_than_or_equal_to(0.0).is_less_than_or_equal_to(99999.999) }
+
+  it { should validate_presence_of(:rate) }
+  it { should validate_numericality_of(:rate).is_greater_than_or_equal_to(0.0).is_less_than_or_equal_to(999999.99) }
+
+  context "::find_rate" do
+    it "should find nothing when there are no rates" do
+      expect(Spree::WeightBasedCalculatorRate.count).to eq(0)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 10)).to be_nil
+    end
+
+    it "should find a valid rate (from a single entry)" do
       rate1.save!
-    end
-  end
 
-  context "with validation errors" do
-    context "from_value" do
-      it "should be entered" do
-        rate1.from_value = nil
-        expect(rate1).to_not be_valid
-        expect(rate1.errors[:from_value].size).to be >= 1
-      end
-
-      it "should not be blank" do
-        rate1.from_value = ''
-        expect(rate1).to_not be_valid
-        expect(rate1.errors[:from_value].size).to be >= 1
-      end
-
-      it "should be numeric" do
-        rate1.from_value = 'foo'
-        expect(rate1).to_not be_valid
-        expect(rate1.errors[:from_value].size).to be >= 1
-      end
-
-      it "should be greater than zero" do
-        rate1.from_value = -10
-        expect(rate1).to_not be_valid
-        expect(rate1.errors[:from_value].size).to be >= 1
-      end
-
+      expect(Spree::WeightBasedCalculatorRate.count).to eq(1)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 0)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 0.1)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 1)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 50)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 99)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 99.9)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 100)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 200.1)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, -5)).to be_nil
     end
 
-    context "rate" do
-      it "should be entered" do
-        rate1.rate = nil
-        expect(rate1).to_not be_valid
-        expect(rate1.errors[:rate].size).to be >= 1
-      end
+    it "should find a valid rate (from two entries)" do
+      rate1.save!
+      rate2.save!
 
-      it "should be numeric" do
-        rate1.rate = 'foo'
-        expect(rate1).to_not be_valid
-        expect(rate1.errors[:rate].size).to be >= 1
-      end
-
-      it "should be greater than zero" do
-        rate1.rate = -10
-        expect(rate1).to_not be_valid
-        expect(rate1.errors[:rate].size).to be >= 1
-      end
-
-    end
-
-    context "find_rate" do
-      it "should find nothing when there are no rates" do
-        expect(Spree::WeightBasedCalculatorRate.count).to eq(0)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 10)).to be_nil
-      end
-
-      it "should find a valid rate (from a single entry)" do
-        rate1.save!
-
-        expect(Spree::WeightBasedCalculatorRate.count).to eq(1)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 0)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 0.1)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 1)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 50)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 99)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 99.9)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 100)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 200.1)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, -5)).to be_nil
-      end
-
-      it "should find a valid rate (from two entries)" do
-        rate1.save!
-        rate2.save!
-
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 0)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 0.1)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 1)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 3)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 7.9)).to eq(10)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 8)).to eq(15)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 8.1)).to eq(15)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 100.1)).to eq(15)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 101)).to eq(15)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 499)).to eq(15)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 499.9)).to eq(15)
-        expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 500)).to eq(15)
-      end
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 0)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 0.1)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 1)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 3)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 7.9)).to eq(10)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 8)).to eq(15)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 8.1)).to eq(15)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 100.1)).to eq(15)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 101)).to eq(15)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 499)).to eq(15)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 499.9)).to eq(15)
+      expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 500)).to eq(15)
     end
   end
 end

--- a/spec/models/spree/weight_based_calculator_rate_spec.rb
+++ b/spec/models/spree/weight_based_calculator_rate_spec.rb
@@ -8,13 +8,13 @@ describe Spree::WeightBasedCalculatorRate do
   let(:calculator) { OpenStruct.new(id: 1) }
 
   let(:rate1) { FactoryGirl.build(:weight_based_calculator_rate,
-                                  :calculator_id => calculator.id,
-                                  :from_value => 0,
-                                  :rate => 10) }
+                                  calculator_id: calculator.id,
+                                  from_value: 0,
+                                  rate: 10) }
   let(:rate2) { FactoryGirl.build(:weight_based_calculator_rate,
-                                  :calculator_id => calculator.id,
-                                  :from_value => 8,
-                                  :rate => 15) }
+                                  calculator_id: calculator.id,
+                                  from_value: 8,
+                                  rate: 15) }
 
   context "without validation errors" do
     it "should not have validation errors with valid attributes" do
@@ -28,25 +28,25 @@ describe Spree::WeightBasedCalculatorRate do
       it "should be entered" do
         rate1.from_value = nil
         expect(rate1).to_not be_valid
-        expect(rate1).to have_at_least(1).errors_on(:from_value)
+        expect(rate1.errors[:from_value].size).to be >= 1
       end
 
       it "should not be blank" do
         rate1.from_value = ''
         expect(rate1).to_not be_valid
-        expect(rate1).to have_at_least(1).errors_on(:from_value)
+        expect(rate1.errors[:from_value].size).to be >= 1
       end
 
       it "should be numeric" do
         rate1.from_value = 'foo'
         expect(rate1).to_not be_valid
-        expect(rate1).to have_at_least(1).errors_on(:from_value)
+        expect(rate1.errors[:from_value].size).to be >= 1
       end
 
       it "should be greater than zero" do
         rate1.from_value = -10
         expect(rate1).to_not be_valid
-        expect(rate1).to have_at_least(1).errors_on(:from_value)
+        expect(rate1.errors[:from_value].size).to be >= 1
       end
 
     end
@@ -55,33 +55,33 @@ describe Spree::WeightBasedCalculatorRate do
       it "should be entered" do
         rate1.rate = nil
         expect(rate1).to_not be_valid
-        expect(rate1).to have_at_least(1).errors_on(:rate)
+        expect(rate1.errors[:rate].size).to be >= 1
       end
 
       it "should be numeric" do
         rate1.rate = 'foo'
         expect(rate1).to_not be_valid
-        expect(rate1).to have_at_least(1).errors_on(:rate)
+        expect(rate1.errors[:rate].size).to be >= 1
       end
 
       it "should be greater than zero" do
         rate1.rate = -10
         expect(rate1).to_not be_valid
-        expect(rate1).to have_at_least(1).errors_on(:rate)
+        expect(rate1.errors[:rate].size).to be >= 1
       end
 
     end
 
     context "find_rate" do
       it "should find nothing when there are no rates" do
-        Spree::WeightBasedCalculatorRate.all.should have(0).records
+        expect(Spree::WeightBasedCalculatorRate.count).to eq(0)
         expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 10)).to be_nil
       end
 
       it "should find a valid rate (from a single entry)" do
         rate1.save!
 
-        expect(Spree::WeightBasedCalculatorRate.all).to have(1).records
+        expect(Spree::WeightBasedCalculatorRate.count).to eq(1)
         expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 0)).to eq(10)
         expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 0.1)).to eq(10)
         expect(Spree::WeightBasedCalculatorRate.find_rate(calculator.id, 1)).to eq(10)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,15 @@ RSpec.configure do |config|
   config.fail_fast = ENV['FAIL_FAST'] || false
 end
 
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
+
+
 if ENV["COVERAGE"]
   # Load all files except the ones in exclude list
   require_all(Dir.glob('**/*.rb') - exlist)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,32 +16,18 @@ ENV['RAILS_ENV'] = 'test'
 
 require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 require 'rspec/rails'
-require 'database_cleaner'
 require 'ffaker'
-
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/support/ and its subdirectories.
-Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 
 # Requires factories defined in spree_core
 require 'spree/testing_support/factories'
-require 'spree/testing_support/controller_requests'
-require 'spree/testing_support/authorization_helpers'
-require 'spree/testing_support/url_helpers'
+require 'rspec/active_model/mocks'
 
 # Requires factories defined in lib/spree_weight_based_shipping_calculator/factories.rb
 require 'spree_weight_based_shipping_calculator/factories'
 
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
-
-  # == URL Helpers
-  #
-  # Allows access to Spree's routes in specs:
-  #
-  # visit spree.admin_path
-  # current_path.should eql(spree.products_path)
-  config.include Spree::TestingSupport::UrlHelpers
+  config.infer_spec_type_from_file_location!
+  config.use_transactional_fixtures = true
 
   # == Mock Framework
   #
@@ -52,31 +38,6 @@ RSpec.configure do |config|
   # config.mock_with :rr
   config.mock_with :rspec
   config.color = true
-
-  ## Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  #config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
-  # Capybara javascript drivers require transactional fixtures set to false, and we use DatabaseCleaner
-  # to cleanup after each test instead.  Without transactional fixtures set to false the records created
-  # to setup a test will be unavailable to the browser, which runs under a seperate server instance.
-  config.use_transactional_fixtures = false
-
-  # Ensure Suite is set to use transactions for speed.
-  config.before :suite do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with :truncation
-  end
-
-  # Before each spec check if it is a Javascript test and switch between using database transactions or not where necessary.
-  config.before :each do
-    DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
-    DatabaseCleaner.start
-  end
-
-  # After each spec clean the database.
-  config.after :each do
-    DatabaseCleaner.clean
-  end
 
   config.fail_fast = ENV['FAIL_FAST'] || false
 end

--- a/spree_weight_based_shipping_calculator.gemspec
+++ b/spree_weight_based_shipping_calculator.gemspec
@@ -17,14 +17,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree_core', '~> 2.2.0'
 
-  s.add_development_dependency 'capybara'
-  s.add_development_dependency 'coffee-rails'
-  s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_girl'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'rspec-rails', '~> 2.14'
-  s.add_development_dependency 'sass-rails'
-  s.add_development_dependency 'selenium-webdriver'
+  s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'rspec-activemodel-mocks'
+  s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
 end

--- a/spree_weight_based_shipping_calculator.gemspec
+++ b/spree_weight_based_shipping_calculator.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rspec-activemodel-mocks'
   s.add_development_dependency 'factory_girl_rails'
+  s.add_development_dependency 'shoulda-matchers'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
Added validations to WeightBasedCalculatorRate for `from_value` and `rate` so that MySQL will not raise errors when a user enters excessively large values.

Primary commits: 70a86c7, 4eb1a11

Removed a lot of unused cruft, updated to rspec 3, added shoulda-matchers gem, and did a little dusting.